### PR TITLE
Mobile hero fix + footer gallery + toolkit grid updates

### DIFF
--- a/src/components/FooterGallery.astro
+++ b/src/components/FooterGallery.astro
@@ -1,0 +1,241 @@
+---
+interface Props {
+  projects: any[];
+}
+
+const { projects } = Astro.props;
+const [p1, p2, p3, p4] = projects;
+---
+
+<section class="fgal reveal">
+  <div class="fgal__canvas">
+
+    <div class="fgal__cell fgal__cell--1">
+      <!-- Pink: rectangle with convex-pillow cutout -->
+      <a href={p1.page} class="fgal__item fgal__item--pink">
+        <div class="fgal__image-wrap">
+          <img src={`${p1.thumbnail}?w=900&q=85&fl=progressive`} alt={p1.title} loading="lazy" decoding="async" />
+        </div>
+        <div class="fgal__mask" aria-hidden="true">
+          <svg viewBox="0 0 450 360" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <mask id="fgal-mask-pink">
+                <rect width="450" height="360" fill="white"/>
+                <path fill="black" d="M 39 0 C 39 0 117 58 235 58 C 354 58 432 0 432 0 C 432 0 432 98 432 148 C 432 198 432 310 432 310 C 432 310 333 266 235 266 C 138 266 39 310 39 310 C 39 310 97 208 97 148 C 97 88 39 0 39 0 Z"/>
+              </mask>
+            </defs>
+            <rect width="450" height="360" fill="#ff4d7e" mask="url(#fgal-mask-pink)"/>
+          </svg>
+        </div>
+      </a>
+      <p class="fgal__caption fgal__caption--1">{p1.title}</p>
+    </div>
+
+    <div class="fgal__cell fgal__cell--2">
+      <!-- Blue: rectangle with circle + vertical strip cutout -->
+      <a href={p2.page} class="fgal__item fgal__item--blue">
+        <div class="fgal__image-wrap">
+          <img src={`${p2.thumbnail}?w=900&q=85&fl=progressive`} alt={p2.title} loading="lazy" decoding="async" />
+        </div>
+        <div class="fgal__mask" aria-hidden="true">
+          <svg viewBox="0 0 787 520" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <mask id="fgal-mask-blue">
+                <rect width="787" height="520" fill="white"/>
+                <ellipse cx="490" cy="258" rx="218" ry="218" fill="black"/>
+                <rect x="690" y="40" width="72" height="436" fill="black"/>
+              </mask>
+            </defs>
+            <rect width="787" height="520" fill="#0557fa" mask="url(#fgal-mask-blue)"/>
+          </svg>
+        </div>
+      </a>
+      <p class="fgal__caption fgal__caption--2">{p2.title}</p>
+    </div>
+
+    <div class="fgal__cell fgal__cell--3">
+      <!-- Orange: rectangle with arch (semicircle) cutout at bottom -->
+      <a href={p3.page} class="fgal__item fgal__item--orange">
+        <div class="fgal__image-wrap">
+          <img src={`${p3.thumbnail}?w=900&q=85&fl=progressive`} alt={p3.title} loading="lazy" decoding="async" />
+        </div>
+        <div class="fgal__mask" aria-hidden="true">
+          <svg viewBox="0 0 338 240" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <mask id="fgal-mask-orange">
+                <rect width="338" height="240" fill="white"/>
+                <ellipse cx="169" cy="228" rx="157" ry="157" fill="black"/>
+                <rect x="0" y="210" width="338" height="30" fill="white"/>
+              </mask>
+            </defs>
+            <rect width="338" height="240" fill="#ed9c31" mask="url(#fgal-mask-orange)"/>
+          </svg>
+        </div>
+      </a>
+      <p class="fgal__caption fgal__caption--3">{p3.title}</p>
+    </div>
+
+    <div class="fgal__cell fgal__cell--4">
+      <!-- Green: rectangle with triangle cutout revealing image -->
+      <a href={p4.page} class="fgal__item fgal__item--green">
+        <div class="fgal__image-wrap">
+          <img src={`${p4.thumbnail}?w=900&q=85&fl=progressive`} alt={p4.title} loading="lazy" decoding="async" />
+        </div>
+        <div class="fgal__mask" aria-hidden="true">
+          <svg viewBox="0 0 503 320" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
+            <defs>
+              <mask id="fgal-mask-green">
+                <rect width="503" height="320" fill="white"/>
+                <polygon points="478,295 478,20.5 215,20.5" fill="black"/>
+              </mask>
+            </defs>
+            <rect width="503" height="320" fill="#008d5e" mask="url(#fgal-mask-green)"/>
+          </svg>
+        </div>
+      </a>
+      <p class="fgal__caption fgal__caption--4">{p4.title}</p>
+    </div>
+
+  </div>
+</section>
+
+<style>
+  .fgal {
+    padding-top: 80px;
+  }
+
+  .fgal__canvas {
+    position: relative;
+    max-width: 1320px;
+    margin: 0 auto;
+    aspect-ratio: 1320 / 1102;
+  }
+
+  /* ── Cell wrappers (transparent on desktop, grid cells on mobile) ── */
+
+  .fgal__cell {
+    display: contents;
+  }
+
+  /* ── Shape items ─────────────────────────────── */
+
+  .fgal__item {
+    position: absolute;
+    overflow: hidden;
+  }
+
+  .fgal__item--pink {
+    left: 0.3%;
+    top: 14.5%;
+    width: 34.1%;
+    aspect-ratio: 450 / 360;
+  }
+
+  .fgal__item--blue {
+    right: 0;
+    top: 0;
+    width: 59.6%;
+    aspect-ratio: 787 / 520;
+  }
+
+  .fgal__item--orange {
+    left: 14.7%;
+    top: 62%;
+    width: 25.6%;
+    aspect-ratio: 338 / 240;
+  }
+
+  .fgal__item--green {
+    left: 47.1%;
+    top: 65.6%;
+    width: 38.1%;
+    aspect-ratio: 503 / 320;
+  }
+
+  /* ── Image layer ─────────────────────────────── */
+
+  .fgal__image-wrap {
+    position: absolute;
+    inset: 0;
+  }
+
+  .fgal__image-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transform-origin: center;
+    will-change: transform;
+  }
+
+  /* ── Mask layer ──────────────────────────────── */
+
+  .fgal__mask {
+    position: absolute;
+    inset: -1px;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .fgal__mask svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+
+  /* ── Captions ────────────────────────────────── */
+
+  .fgal__caption {
+    position: absolute;
+    margin: 0;
+    font-size: clamp(10px, 1.38vw, 18px);
+    line-height: 1.1;
+    color: #EFF0EC;
+  }
+
+  .fgal__caption--1 { left: 0.3%;  width: 34.1%; top: 49%;  }
+  .fgal__caption--2 { left: 40.5%; width: 59.5%; top: 49%;  }
+  .fgal__caption--3 { left: 14.7%; width: 25.6%; top: 86%; text-align: right; }
+  .fgal__caption--4 { left: 47.1%; width: 38.1%; top: 96%;  }
+
+  /* ── Image animations ────────────────────────── */
+
+  .fgal__item--pink   .fgal__image-wrap img { animation: fgal-img-1 14s ease-in-out infinite alternate; }
+  .fgal__item--blue   .fgal__image-wrap img { animation: fgal-img-2 11s ease-in-out infinite alternate; animation-delay: -3s; }
+  .fgal__item--orange .fgal__image-wrap img { animation: fgal-img-3 13s ease-in-out infinite alternate; animation-delay: -6s; }
+  .fgal__item--green  .fgal__image-wrap img { animation: fgal-img-4 12s ease-in-out infinite alternate; animation-delay: -2s; }
+
+  @keyframes fgal-img-1 {
+    from { transform: scale(1.12) translate(0, 0); }
+    to   { transform: scale(1.06) translate(-4%, 3%); }
+  }
+  @keyframes fgal-img-2 {
+    from { transform: scale(1.12) translate(0, 0); }
+    to   { transform: scale(1.07) translate(3%, -2%); }
+  }
+  @keyframes fgal-img-3 {
+    from { transform: scale(1.12) translate(0, 0); }
+    to   { transform: scale(1.06) translate(2%, 4%); }
+  }
+  @keyframes fgal-img-4 {
+    from { transform: scale(1.12) translate(0, 0); }
+    to   { transform: scale(1.08) translate(-3%, -2%); }
+  }
+
+  /* ── Reduced motion ──────────────────────────── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .fgal__image-wrap img {
+      animation: none !important;
+      transform: scale(1.12) !important;
+    }
+  }
+
+  /* ── Responsive ──────────────────────────────── */
+
+  @media screen and (max-width: 767px) {
+    .fgal {
+      padding-top: 40px;
+    }
+  }
+</style>

--- a/src/components/ProjectMeta.astro
+++ b/src/components/ProjectMeta.astro
@@ -1,16 +1,51 @@
 ---
 interface Props {
-  toolkit: string;
+  toolkit: string[];
+  color?: string;
 }
 
-const { toolkit } = Astro.props;
+const { toolkit, color } = Astro.props;
 ---
 
 <section class="section">
-  <div class="block-grid">
-    <div class="project-meta">
-      <h2>Toolkit</h2>
-      <div>{toolkit}</div>
-    </div>
+  <div class="project-meta">
+    <h2 style={color ? `color: ${color}` : ''}>Toolkit</h2>
+    <ul class="toolkit-grid">
+      {toolkit.map(tag => (
+        <li class="toolkit-item">{tag}</li>
+      ))}
+    </ul>
   </div>
 </section>
+
+<style>
+  .project-meta h2 {
+    margin-bottom: 24px;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.02em;
+  }
+
+  .toolkit-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    column-gap: 30px;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .toolkit-item {
+    border-top: 1px solid rgba(236, 240, 243, 0.2);
+    padding-top: 14px;
+    padding-bottom: 24px;
+    font-size: 16px;
+    color: rgba(236, 240, 243, 0.65);
+  }
+
+  @media screen and (max-width: 767px) {
+    .toolkit-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+</style>

--- a/src/components/ProjectMeta.astro
+++ b/src/components/ProjectMeta.astro
@@ -19,17 +19,10 @@ const { toolkit, color } = Astro.props;
 </section>
 
 <style>
-  .project-meta h2 {
-    margin-bottom: 24px;
-    font-size: 14px;
-    font-weight: 400;
-    letter-spacing: 0.02em;
-  }
-
   .toolkit-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    column-gap: 30px;
+    column-gap: 16px;
     list-style: none;
     padding: 0;
     margin: 0;
@@ -37,8 +30,8 @@ const { toolkit, color } = Astro.props;
 
   .toolkit-item {
     border-top: 1px solid rgba(236, 240, 243, 0.2);
-    padding-top: 14px;
-    padding-bottom: 24px;
+    padding-top: 10px;
+    padding-bottom: 16px;
     font-size: 16px;
     color: rgba(236, 240, 243, 0.65);
   }

--- a/src/components/ProjectMeta.astro
+++ b/src/components/ProjectMeta.astro
@@ -1,18 +1,13 @@
 ---
 interface Props {
-  client: string;
   toolkit: string;
 }
 
-const { client, toolkit } = Astro.props;
+const { toolkit } = Astro.props;
 ---
 
 <section class="section">
   <div class="block-grid">
-    <div class="project-meta">
-      <h2>Client</h2>
-      <div>{client}</div>
-    </div>
     <div class="project-meta">
       <h2>Toolkit</h2>
       <div>{toolkit}</div>

--- a/src/data/projects.yaml
+++ b/src/data/projects.yaml
@@ -6,7 +6,10 @@ qf:
   crop: 'faces'
   page: '/project/qatar-foundation-navigation-redesign'
   client: 'Qatar Foundation'
-  toolkit: 'Information Architecture · Interaction Design · UX Research'
+  toolkit:
+    - Information Architecture
+    - Interaction Design
+    - UX Research
   documentation:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/4OD7IfWs8vQb4oOeVmyLH6/f22fc60d92095a55ae4c11924a6ef233/QF_Navigation_Redesign_____Research_3.jpg'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/57f2xHqpP5uc6yMATZZxMQ/6dae6fc89d9e34927009670773e2c1a6/QF_Navigation_Redesign_____Research_4.jpg'
@@ -29,7 +32,11 @@ healthdesk:
   crop: 'center'
   page: '/project/health-desk'
   client: 'Meedan'
-  toolkit: 'Brand Identity · Product Design · Design System · Frontend'
+  toolkit:
+    - Brand Identity
+    - Product Design
+    - Design System
+    - Frontend
 guardias-da-resistencia-podcast:
   title: 'Guardiãs da Resistência Podcast'
   color: '#E6F1FF'
@@ -38,7 +45,9 @@ guardias-da-resistencia-podcast:
   crop: 'center'
   page: '/project/guardias-da-resistencia-podcast'
   client: 'Meedan'
-  toolkit: 'Brand Identity · Editorial Design'
+  toolkit:
+    - Brand Identity
+    - Editorial Design
   social:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2XFdeSlU24WNlfLg3ZsOt4/37837a0d8cd118fdfc3d7e9246ba10f7/Title.png'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/3kn1E0yDNbihSz5E74l0re/0c6f23a008064c94f67d1976b0afacb0/Quote___Image.png'
@@ -54,7 +63,10 @@ misinfodemia:
   crop: 'center'
   page: '/project/misinfodemia'
   client: 'Meedan'
-  toolkit: 'Brand Identity · Editorial Design · Web Design'
+  toolkit:
+    - Brand Identity
+    - Editorial Design
+    - Web Design
 credcat:
   title: 'Meedan — Credibility Catalog'
   color: '#BAFCFF'
@@ -63,7 +75,10 @@ credcat:
   crop: 'faces'
   page: '/project/meedan-credibility-catalog'
   client: 'Meedan, Hacks/Hackers'
-  toolkit: 'Product Design · Interaction Design · Frontend'
+  toolkit:
+    - Product Design
+    - Interaction Design
+    - Frontend
   case:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2Q7tF4zALUArRuQlASXv92/616f6f9f17771d8d384d142281fb5f2c/Credibility_Catalog_-_case_-_1.png'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2bEs9rleect5lIFOEehT88/9827488209abd6801b1c60d9af845c1c/Credibility_Catalog_-_case_-_2.png'
@@ -90,7 +105,10 @@ presentation-meedan-team-survey-results:
   crop: 'center'
   page: '/project/presentation-meedan-team-survey-results'
   client: 'Meedan'
-  toolkit: 'Data Visualization · Editorial Design · Presentation Design'
+  toolkit:
+    - Data Visualization
+    - Editorial Design
+    - Presentation Design
   social:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/6SHR2tll3CSWet93aXkhh5/afcc6aeb08c4cb143d1776bcecde98a6/Meedan_Team_Survey_and_EDI_Results_2019-2021.jpeg'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/7vHOkKApCX8jcz2buN3n8F/96ba72aa8e44bda3ced1e754580c80c9/Meedan_Team_Survey_Results_2019-2021_3.jpeg'
@@ -119,7 +137,11 @@ presentation-meedan-team-survey-results:
   crop: 'center'
   page: '/project/2020-misinfodemic-report'
   client: 'Meedan'
-  toolkit: 'Report Design · Editorial Design · Illustration · Web Design'
+  toolkit:
+    - Report Design
+    - Editorial Design
+    - Illustration
+    - Web Design
   covers:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/7n8oIAZ7xT2mFt0uJZIQii/cb838c541427fd15c30618d7142b9056/meedan_report_covid-19-kenya_africa-check_01.png'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2ixL6uCPWuMZ1eMj4i5qPr/96e7f2003ed6dab7fbdc2959c64d516b/meedan_report_covid-19-india_01.png'

--- a/src/data/projects.yaml
+++ b/src/data/projects.yaml
@@ -6,7 +6,7 @@ qf:
   crop: 'faces'
   page: '/project/qatar-foundation-navigation-redesign'
   client: 'Qatar Foundation'
-  toolkit: 'UX, UI design'
+  toolkit: 'Information Architecture · Interaction Design · UX Research'
   documentation:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/4OD7IfWs8vQb4oOeVmyLH6/f22fc60d92095a55ae4c11924a6ef233/QF_Navigation_Redesign_____Research_3.jpg'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/57f2xHqpP5uc6yMATZZxMQ/6dae6fc89d9e34927009670773e2c1a6/QF_Navigation_Redesign_____Research_4.jpg'
@@ -29,7 +29,7 @@ healthdesk:
   crop: 'center'
   page: '/project/health-desk'
   client: 'Meedan'
-  toolkit: 'Branding and Identity, UX, UI design, Design System, Jamstack, Frontend'
+  toolkit: 'Brand Identity · Product Design · Design System · Frontend'
 guardias-da-resistencia-podcast:
   title: 'Guardiãs da Resistência Podcast'
   color: '#E6F1FF'
@@ -38,7 +38,7 @@ guardias-da-resistencia-podcast:
   crop: 'center'
   page: '/project/guardias-da-resistencia-podcast'
   client: 'Meedan'
-  toolkit: 'Branding and Identity'
+  toolkit: 'Brand Identity · Editorial Design'
   social:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2XFdeSlU24WNlfLg3ZsOt4/37837a0d8cd118fdfc3d7e9246ba10f7/Title.png'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/3kn1E0yDNbihSz5E74l0re/0c6f23a008064c94f67d1976b0afacb0/Quote___Image.png'
@@ -54,7 +54,7 @@ misinfodemia:
   crop: 'center'
   page: '/project/misinfodemia'
   client: 'Meedan'
-  toolkit: 'Branding and Identity, Web Design'
+  toolkit: 'Brand Identity · Editorial Design · Web Design'
 credcat:
   title: 'Meedan — Credibility Catalog'
   color: '#BAFCFF'
@@ -63,7 +63,7 @@ credcat:
   crop: 'faces'
   page: '/project/meedan-credibility-catalog'
   client: 'Meedan, Hacks/Hackers'
-  toolkit: 'UX, UI design, Jamstack, Frontend'
+  toolkit: 'Product Design · Interaction Design · Frontend'
   case:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2Q7tF4zALUArRuQlASXv92/616f6f9f17771d8d384d142281fb5f2c/Credibility_Catalog_-_case_-_1.png'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2bEs9rleect5lIFOEehT88/9827488209abd6801b1c60d9af845c1c/Credibility_Catalog_-_case_-_2.png'
@@ -90,7 +90,7 @@ presentation-meedan-team-survey-results:
   crop: 'center'
   page: '/project/presentation-meedan-team-survey-results'
   client: 'Meedan'
-  toolkit: 'Presentation Design, Poster'
+  toolkit: 'Data Visualization · Editorial Design · Presentation Design'
   social:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/6SHR2tll3CSWet93aXkhh5/afcc6aeb08c4cb143d1776bcecde98a6/Meedan_Team_Survey_and_EDI_Results_2019-2021.jpeg'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/7vHOkKApCX8jcz2buN3n8F/96ba72aa8e44bda3ced1e754580c80c9/Meedan_Team_Survey_Results_2019-2021_3.jpeg'
@@ -119,7 +119,7 @@ presentation-meedan-team-survey-results:
   crop: 'center'
   page: '/project/2020-misinfodemic-report'
   client: 'Meedan'
-  toolkit: 'Web Design, Illustration, Report Design'
+  toolkit: 'Report Design · Editorial Design · Illustration · Web Design'
   covers:
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/7n8oIAZ7xT2mFt0uJZIQii/cb838c541427fd15c30618d7142b9056/meedan_report_covid-19-kenya_africa-check_01.png'
     - image: 'https://images.ctfassets.net/2orm8gd3ce6v/2ixL6uCPWuMZ1eMj4i5qPr/96e7f2003ed6dab7fbdc2959c64d516b/meedan_report_covid-19-india_01.png'

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,5 +38,5 @@ import projects from '../data/projects.yaml';
     </div>
   </section>
 
-  <FooterGallery projects={Object.values(projects).slice(0, 4)} />
+  <FooterGallery projects={[projects.qf, projects.healthdesk, projects.credcat, projects.misinfodemia]} />
 </BaseLayout>

--- a/src/pages/information/index.astro
+++ b/src/pages/information/index.astro
@@ -1,33 +1,8 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import TextBlock from '../../components/TextBlock.astro';
 ---
 
 <BaseLayout title="Designbysoil – Work of Abdul Rehman Khawar">
-  <section class="section">
-    <TextBlock heading="Information" text="If you're interested in any form of collaboration, please send an email and I'll get back shortly." />
-  </section>
-  <section class="section">
-    <div class="grid-list four-columns">
-      <h2 class="title">Connect</h2>
-      <div>
-        <div class="label">Mail</div>
-        <div><a href="mailto:mail@designbysoil.com">mail@designbysoil.com</a></div>
-      </div>
-      <div>
-        <div class="label">Phone</div>
-        <div><a href="tel:0016047798640">+1 604 7798640</a></div>
-      </div>
-      <div>
-        <div class="label">Twitter</div>
-        <div><a href="https://twitter.com/designbysoil">designbysoil&#8599;</a></div>
-      </div>
-      <div>
-        <div class="label">LinkedIn</div>
-        <div><a href="https://ca.linkedin.com/in/abdulrehman">ark&#8599;</a></div>
-      </div>
-    </div>
-  </section>
   <section class="section">
     <div class="grid-list">
       <h2 class="title">Experience</h2>

--- a/src/pages/project/2020-misinfodemic-report/index.astro
+++ b/src/pages/project/2020-misinfodemic-report/index.astro
@@ -17,7 +17,7 @@ const coversSlides = project.covers;
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
   <TextBlock heading="" text="An interdisciplinary collection of reports and essays that seek to map the anotomy of a global pandemic." />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/2ZuotuL4EURiH8Td8y3NSp/9f601a0b627d6daa7eb5490678d0b802/meedan-2020-misinfodemic-report_laptop.png" />
   <GridFull
     image1Url="https://images.ctfassets.net/2orm8gd3ce6v/4Yq7yVigaxGf5FKoWPHAjw/edcc747376c40ddf6d24ea01b9c3017a/Meedan_2020_Misinfodemic_Report_Covers_Tablet.png"

--- a/src/pages/project/2020-misinfodemic-report/index.astro
+++ b/src/pages/project/2020-misinfodemic-report/index.astro
@@ -17,7 +17,7 @@ const coversSlides = project.covers;
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
   <TextBlock heading="" text="An interdisciplinary collection of reports and essays that seek to map the anotomy of a global pandemic." />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/2ZuotuL4EURiH8Td8y3NSp/9f601a0b627d6daa7eb5490678d0b802/meedan-2020-misinfodemic-report_laptop.png" />
   <GridFull
     image1Url="https://images.ctfassets.net/2orm8gd3ce6v/4Yq7yVigaxGf5FKoWPHAjw/edcc747376c40ddf6d24ea01b9c3017a/Meedan_2020_Misinfodemic_Report_Covers_Tablet.png"

--- a/src/pages/project/guardias-da-resistencia-podcast/index.astro
+++ b/src/pages/project/guardias-da-resistencia-podcast/index.astro
@@ -16,7 +16,7 @@ const socialSlides = project.social;
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
   <TextBlock heading="" text="A podcast about exploring memory as a form of cultural insurgency. Connecting people through memory, regional archives and counter-archives. Recorded in Portuguese." />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/5F46rpK4TtCqATK0ZQoJUk/ddcdfc9c717ec13b0a0bf7ef15fcb2ce/Guardia__s_da_Resiste__ncia_____Social.png" />
   <GridFull
     image1Url="https://images.ctfassets.net/2orm8gd3ce6v/6svsoq2boGHVweOtnfsHBU/74848f5ad75d34df32442eb8bdbf7a63/Guardia__s_da_Resiste__ncia_____Phone.png"

--- a/src/pages/project/guardias-da-resistencia-podcast/index.astro
+++ b/src/pages/project/guardias-da-resistencia-podcast/index.astro
@@ -16,7 +16,7 @@ const socialSlides = project.social;
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
   <TextBlock heading="" text="A podcast about exploring memory as a form of cultural insurgency. Connecting people through memory, regional archives and counter-archives. Recorded in Portuguese." />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/5F46rpK4TtCqATK0ZQoJUk/ddcdfc9c717ec13b0a0bf7ef15fcb2ce/Guardia__s_da_Resiste__ncia_____Social.png" />
   <GridFull
     image1Url="https://images.ctfassets.net/2orm8gd3ce6v/6svsoq2boGHVweOtnfsHBU/74848f5ad75d34df32442eb8bdbf7a63/Guardia__s_da_Resiste__ncia_____Phone.png"

--- a/src/pages/project/health-desk/index.astro
+++ b/src/pages/project/health-desk/index.astro
@@ -13,7 +13,7 @@ const project = projects.healthdesk;
 
 <BaseLayout title="Meedan – Health Desk">
   <ProjectHero imageUrl={project.hero} title="Meedan – Health Desk" />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/5T7gnpHKrGl5uJrIAiDxwc/0fce625561efde096f1577b7e9b89fd0/Health_Desk_-_Documentation_-_10.png" />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/5EoRZJLW9ErkeBJWjtUBmu/42d1f17cd2d9f048d255c6df09a38060/Health_Desk_-_Documentation_-_9.png" />
   <GridFullCenter

--- a/src/pages/project/health-desk/index.astro
+++ b/src/pages/project/health-desk/index.astro
@@ -13,7 +13,7 @@ const project = projects.healthdesk;
 
 <BaseLayout title="Meedan – Health Desk">
   <ProjectHero imageUrl={project.hero} title="Meedan – Health Desk" />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/5T7gnpHKrGl5uJrIAiDxwc/0fce625561efde096f1577b7e9b89fd0/Health_Desk_-_Documentation_-_10.png" />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/5EoRZJLW9ErkeBJWjtUBmu/42d1f17cd2d9f048d255c6df09a38060/Health_Desk_-_Documentation_-_9.png" />
   <GridFullCenter

--- a/src/pages/project/meedan-credibility-catalog/index.astro
+++ b/src/pages/project/meedan-credibility-catalog/index.astro
@@ -17,7 +17,7 @@ const project = projects.credcat;
 <BaseLayout title="Meedan — Credibility Catalog">
   <ProjectHero imageUrl={project.hero} title="Meedan — Credibility Catalog" />
   <TextBlock heading="Challenge" text="Meedan, together with Hacks/Hackers, wanted to develop an interactive tool to support initiatives working to improve information quality. Using the tool, potential funders, researchers and practitioners needed to filter credibility initiatives from around the world by contextual factors like language and region. Plus what approaches the initiatives were using to combat misinformation." />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/2ywkbnSuZ0RWb8zxaFCOOX/1b1d76612465532d6cc724a5aae4e24a/meedan-credcat-macbook.jpg" />
   <ImageSlideshow slides={project.case} />
   <TextBlock heading="Solution" text="Started with wireframes to develop a way to visualize the initiatives based on the four areas of focus as well as across regions and languages. Each initiative would be represented as four blocks of color mapped to its area of focus. The design needed to be engaging yet straightforward, enabling users from varied backgrounds to easily comprehend and extract valuable insights from the data." />

--- a/src/pages/project/meedan-credibility-catalog/index.astro
+++ b/src/pages/project/meedan-credibility-catalog/index.astro
@@ -17,7 +17,7 @@ const project = projects.credcat;
 <BaseLayout title="Meedan — Credibility Catalog">
   <ProjectHero imageUrl={project.hero} title="Meedan — Credibility Catalog" />
   <TextBlock heading="Challenge" text="Meedan, together with Hacks/Hackers, wanted to develop an interactive tool to support initiatives working to improve information quality. Using the tool, potential funders, researchers and practitioners needed to filter credibility initiatives from around the world by contextual factors like language and region. Plus what approaches the initiatives were using to combat misinformation." />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/2ywkbnSuZ0RWb8zxaFCOOX/1b1d76612465532d6cc724a5aae4e24a/meedan-credcat-macbook.jpg" />
   <ImageSlideshow slides={project.case} />
   <TextBlock heading="Solution" text="Started with wireframes to develop a way to visualize the initiatives based on the four areas of focus as well as across regions and languages. Each initiative would be represented as four blocks of color mapped to its area of focus. The design needed to be engaging yet straightforward, enabling users from varied backgrounds to easily comprehend and extract valuable insights from the data." />

--- a/src/pages/project/misinfodemia/index.astro
+++ b/src/pages/project/misinfodemia/index.astro
@@ -13,7 +13,7 @@ const project = projects['misinfodemia'];
 
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/137TC26ncK4Y8gI0T7Li2q/7332bbf941807209822dc0a1a164004c/meedan_misinfodemia_09_with-by-b-1.png" />
   <GridFull
     image1Url="https://images.ctfassets.net/2orm8gd3ce6v/XkJM6QCflF3PmPulkENbB/d95eb8daea35c7f00dc7d0c58fed6bb7/meedan_misinfodemia_09_with-by-b.png"

--- a/src/pages/project/misinfodemia/index.astro
+++ b/src/pages/project/misinfodemia/index.astro
@@ -13,7 +13,7 @@ const project = projects['misinfodemia'];
 
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/137TC26ncK4Y8gI0T7Li2q/7332bbf941807209822dc0a1a164004c/meedan_misinfodemia_09_with-by-b-1.png" />
   <GridFull
     image1Url="https://images.ctfassets.net/2orm8gd3ce6v/XkJM6QCflF3PmPulkENbB/d95eb8daea35c7f00dc7d0c58fed6bb7/meedan_misinfodemia_09_with-by-b.png"

--- a/src/pages/project/presentation-meedan-team-survey-results/index.astro
+++ b/src/pages/project/presentation-meedan-team-survey-results/index.astro
@@ -15,7 +15,7 @@ const socialSlides = project.social;
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
   <TextBlock heading="" text="Presentation design for the the annual end-of-year organizational feedback survey results." />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/C7VmBmlyIzeLlizkrbRA4/d009c4d100c888237977e19e7feb501f/meedan-team-survey-results-presentation_tablet.png" />
   <ImageCarousel slides={socialSlides} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/2jmP1Cj2qfAb6cu4VnjVgJ/c90a77266180ecb4340116195d7ac5ed/meedan-team-survey-results-presentation_poster.png" />

--- a/src/pages/project/presentation-meedan-team-survey-results/index.astro
+++ b/src/pages/project/presentation-meedan-team-survey-results/index.astro
@@ -15,7 +15,7 @@ const socialSlides = project.social;
 <BaseLayout title={project.title}>
   <ProjectHero imageUrl={project.hero} title={project.title} />
   <TextBlock heading="" text="Presentation design for the the annual end-of-year organizational feedback survey results." />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/C7VmBmlyIzeLlizkrbRA4/d009c4d100c888237977e19e7feb501f/meedan-team-survey-results-presentation_tablet.png" />
   <ImageCarousel slides={socialSlides} />
   <ImageFullBleed imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/2jmP1Cj2qfAb6cu4VnjVgJ/c90a77266180ecb4340116195d7ac5ed/meedan-team-survey-results-presentation_poster.png" />

--- a/src/pages/project/qatar-foundation-navigation-redesign/index.astro
+++ b/src/pages/project/qatar-foundation-navigation-redesign/index.astro
@@ -24,7 +24,7 @@ const display_slides = project.display;
     heading="Challenge"
     text="Qatar Foundation is a unique non-profit organization from Qatar. With around 50 entities working in education, research and community development. After a successful website redesign, they needed to revisit their website navigation to increase content discovery and findability for their wide range of audience."
   />
-  <ProjectMeta client={project.client} toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} />
   <ImageCentered
     imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/4nFf8YRrSwCiSQynuda04R/bfcac58dcd79cd9dec8c8e9f484967ab/Landing_page_G1_no_background_1.jpg"
     align="bottom"

--- a/src/pages/project/qatar-foundation-navigation-redesign/index.astro
+++ b/src/pages/project/qatar-foundation-navigation-redesign/index.astro
@@ -24,7 +24,7 @@ const display_slides = project.display;
     heading="Challenge"
     text="Qatar Foundation is a unique non-profit organization from Qatar. With around 50 entities working in education, research and community development. After a successful website redesign, they needed to revisit their website navigation to increase content discovery and findability for their wide range of audience."
   />
-  <ProjectMeta toolkit={project.toolkit} />
+  <ProjectMeta toolkit={project.toolkit} color={project.color} />
   <ImageCentered
     imageUrl="https://images.ctfassets.net/2orm8gd3ce6v/4nFf8YRrSwCiSQynuda04R/bfcac58dcd79cd9dec8c8e9f484967ab/Landing_page_G1_no_background_1.jpg"
     align="bottom"

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -529,6 +529,10 @@ a {
     .homepage-hero {
         display: flex;
         flex-direction: column-reverse;
+
+        .homepage-hero-image {
+            align-self: stretch;
+        }
     }
 
     .header-wrapper,


### PR DESCRIPTION
## Summary
- Fix hero art invisible on mobile — `align-self: flex-start` was collapsing the image container in the column-reverse flex layout
- Add footer gallery section with 4 shaped project frames
- Render toolkit as 3-col grid with top rules matching Figma, with tightened spacing and normalized heading style
- Remove client from project meta and expand toolkit taxonomy
- Remove Information and Connect sections from information page

## Test plan
- [ ] Verify animated hero art is visible on mobile (≤767px) and tablet (≤991px)
- [ ] Check footer gallery renders correctly across breakpoints
- [ ] Confirm toolkit grid layout matches Figma spec
- [ ] Review information page for removed sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)