### PR TITLE
Upgrade to Astro 7 + Contentful image performance refactor

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,6 +6,12 @@ import yaml from '@rollup/plugin-yaml';
 export default defineConfig({
   site: 'https://designbysoil.com',
   output: 'static',
+  build: {
+    // Inline all CSS into the HTML to remove render-blocking stylesheet
+    // requests on the critical path (improves FCP/LCP). The site's CSS is
+    // small, so the per-page HTML cost is negligible.
+    inlineStylesheets: 'always',
+  },
   integrations: [
     sitemap(),
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "engines": {
-    "node": ">=18.17.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "dev": "astro dev",
@@ -12,9 +12,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/sitemap": "^3.7.2",
+    "@astrojs/sitemap": "^3.7.3",
     "@rollup/plugin-yaml": "^4.1.2",
-    "astro": "^6.3.7",
+    "astro": "^7.0.4",
     "sass": "^1.100.0"
   }
 }

--- a/src/components/BlurImage.astro
+++ b/src/components/BlurImage.astro
@@ -8,9 +8,10 @@ interface Props {
   alt?: string;
   class?: string;
   loading?: 'lazy' | 'eager';
+  fetchpriority?: 'high' | 'low' | 'auto';
 }
 
-const { src, srcset, sizes, alt = '', loading = 'lazy', class: className } = Astro.props;
+const { src, srcset, sizes, alt = '', loading = 'lazy', fetchpriority, class: className } = Astro.props;
 const placeholder = await getPlaceholder(src);
 ---
 
@@ -25,6 +26,8 @@ const placeholder = await getPlaceholder(src);
     sizes={sizes}
     alt={alt}
     loading={loading}
+    fetchpriority={fetchpriority}
+    decoding="async"
   />
 </div>
 

--- a/src/components/FullBleedSlideshow.astro
+++ b/src/components/FullBleedSlideshow.astro
@@ -1,4 +1,6 @@
 ---
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
+
 interface Props {
   slides: { image: string }[];
   imageClass?: string;
@@ -17,11 +19,12 @@ const { slides, imageClass } = Astro.props;
           role="group"
         >
           <img
-            src={slide.image}
+            src={cdnUrl(slide.image, { w: 1080 })}
             sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 91vw"
-            srcset={`${slide.image}?fl=progressive&q=90&w=500 500w, ${slide.image}?fl=progressive&q=90&w=800 800w, ${slide.image}?fl=progressive&q=90&w=1080 1080w, ${slide.image} 1318w`}
+            srcset={cdnSrcset(slide.image, [500, 800, 1080, 1318])}
             alt=""
             loading="lazy"
+            decoding="async"
             class={imageClass}
           />
         </div>

--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -1,4 +1,6 @@
 ---
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
+
 interface Props {
   projects: any[];
 }
@@ -6,8 +8,13 @@ interface Props {
 const { projects } = Astro.props;
 const [p1, p2, p3, p4] = projects;
 
-const imgSrc = (url: string) =>
-  url.startsWith('http') ? `${url}?w=900&q=85&fl=progressive` : url;
+// Gallery sources may be local (/gallery/*.png) or Contentful URLs. The cdn*
+// helpers transform only Contentful URLs and pass local paths through unchanged
+// (cdnSrcset returns undefined, so the <img> falls back to its src).
+const GALLERY_WIDTHS = [450, 600, 900, 1200, 1800];
+const GALLERY_SIZES = '(max-width: 767px) 90vw, 45vw';
+const galSrc = (url: string) => cdnUrl(url, { w: 900, q: 85 });
+const galSrcset = (url: string) => cdnSrcset(url, GALLERY_WIDTHS, { q: 85 });
 ---
 
 <section class="fgal reveal">
@@ -18,7 +25,7 @@ const imgSrc = (url: string) =>
         <div class="fgal__scale-wrap">
           <a href={p1.page} class="fgal__item fgal__item--pink">
             <div class="fgal__image-wrap">
-              <img src={imgSrc(p1.gallerySrc ?? p1.thumbnail)} alt={p1.title} loading="lazy" decoding="async" />
+              <img src={galSrc(p1.gallerySrc ?? p1.thumbnail)} srcset={galSrcset(p1.gallerySrc ?? p1.thumbnail)} sizes={GALLERY_SIZES} alt={p1.title} loading="lazy" decoding="async" />
             </div>
             <div class="fgal__mask" aria-hidden="true">
               <svg viewBox="0 0 450 360" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
@@ -42,7 +49,7 @@ const imgSrc = (url: string) =>
         <div class="fgal__scale-wrap">
           <a href={p2.page} class="fgal__item fgal__item--blue">
             <div class="fgal__image-wrap">
-              <img src={imgSrc(p2.gallerySrc ?? p2.thumbnail)} alt={p2.title} loading="lazy" decoding="async" />
+              <img src={galSrc(p2.gallerySrc ?? p2.thumbnail)} srcset={galSrcset(p2.gallerySrc ?? p2.thumbnail)} sizes={GALLERY_SIZES} alt={p2.title} loading="lazy" decoding="async" />
             </div>
             <div class="fgal__mask" aria-hidden="true">
               <svg viewBox="0 0 787 520" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
@@ -67,7 +74,7 @@ const imgSrc = (url: string) =>
         <div class="fgal__scale-wrap">
           <a href={p3.page} class="fgal__item fgal__item--orange">
             <div class="fgal__image-wrap">
-              <img src={imgSrc(p3.gallerySrc ?? p3.thumbnail)} alt={p3.title} loading="lazy" decoding="async" />
+              <img src={galSrc(p3.gallerySrc ?? p3.thumbnail)} srcset={galSrcset(p3.gallerySrc ?? p3.thumbnail)} sizes={GALLERY_SIZES} alt={p3.title} loading="lazy" decoding="async" />
             </div>
             <div class="fgal__mask" aria-hidden="true">
               <svg viewBox="0 0 338 240" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">
@@ -92,7 +99,7 @@ const imgSrc = (url: string) =>
         <div class="fgal__scale-wrap">
           <a href={p4.page} class="fgal__item fgal__item--green">
             <div class="fgal__image-wrap">
-              <img src={imgSrc(p4.gallerySrc ?? p4.thumbnail)} alt={p4.title} loading="lazy" decoding="async" />
+              <img src={galSrc(p4.gallerySrc ?? p4.thumbnail)} srcset={galSrcset(p4.gallerySrc ?? p4.thumbnail)} sizes={GALLERY_SIZES} alt={p4.title} loading="lazy" decoding="async" />
             </div>
             <div class="fgal__mask" aria-hidden="true">
               <svg viewBox="0 0 503 320" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/GridFull.astro
+++ b/src/components/GridFull.astro
@@ -1,5 +1,6 @@
 ---
 import BlurImage from './BlurImage.astro';
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
 
 interface Props {
   image1Url: string;
@@ -14,17 +15,17 @@ const { image1Url, image2Url, credit } = Astro.props;
   <div class="block-grid">
     <div class="block-image">
       <BlurImage
-        src={image1Url}
+        src={cdnUrl(image1Url, { w: 645 })}
         sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 44vw"
-        srcset={`${image1Url}?fl=progressive&q=90&w=500 500w, ${image1Url} 645w`}
+        srcset={cdnSrcset(image1Url, [500, 645])}
         class="image"
       />
     </div>
     <div class="block-image">
       <BlurImage
-        src={image2Url}
+        src={cdnUrl(image2Url, { w: 645 })}
         sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 44vw"
-        srcset={`${image2Url}?fl=progressive&q=90&w=500 500w, ${image2Url} 645w`}
+        srcset={cdnSrcset(image2Url, [500, 645])}
         class="image"
       />
     </div>

--- a/src/components/GridFullCenter.astro
+++ b/src/components/GridFullCenter.astro
@@ -1,5 +1,6 @@
 ---
 import BlurImage from './BlurImage.astro';
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
 
 interface Props {
   fullImageUrl: string;
@@ -21,15 +22,15 @@ const darkStyle = [
   <div class="block-grid">
     <div class="block-image">
       <BlurImage
-        src={fullImageUrl}
+        src={cdnUrl(fullImageUrl, { w: 645 })}
         sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 44vw"
-        srcset={`${fullImageUrl}?fl=progressive&q=90&w=500 500w, ${fullImageUrl} 645w`}
+        srcset={cdnSrcset(fullImageUrl, [500, 645])}
         class="image"
       />
     </div>
     <div class="block-image dark" style={darkStyle || undefined}>
       <div class="black-image-center">
-        <BlurImage src={centerImageUrl} />
+        <BlurImage src={cdnUrl(centerImageUrl, { w: 800 })} srcset={cdnSrcset(centerImageUrl, [400, 800])} sizes="(max-width: 767px) 80vw, 40vw" />
       </div>
     </div>
   </div>

--- a/src/components/ImageCarousel.astro
+++ b/src/components/ImageCarousel.astro
@@ -1,4 +1,6 @@
 ---
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
+
 interface Props {
   slides: { image: string }[];
   border?: boolean;
@@ -18,10 +20,11 @@ const { slides, border = false } = Astro.props;
         >
           <img
             sizes="(max-width: 479px) 100vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 82vw"
-            srcset={`${slide.image}?fl=progressive&q=90&w=500 500w, ${slide.image}?fl=progressive&q=90&w=800 800w, ${slide.image}?fl=progressive&q=90&w=1080 1080w, ${slide.image}?fl=progressive&q=90&w=1600 1600w, ${slide.image}?fl=progressive&q=90&w=2000 2000w, ${slide.image}?fl=progressive&q=90&w=2600 2600w, ${slide.image}?fl=progressive&q=90&w=3200 3200w, ${slide.image}?fl=progressive&q=90&w=3840 3840w`}
-            src={`${slide.image}?fl=progressive`}
+            srcset={cdnSrcset(slide.image, [500, 800, 1080, 1600, 2000, 2600, 3200, 3840])}
+            src={cdnUrl(slide.image, { w: 1600 })}
             alt=""
             loading="lazy"
+            decoding="async"
           />
         </div>
       ))}

--- a/src/components/ImageCarouselWithText.astro
+++ b/src/components/ImageCarouselWithText.astro
@@ -1,4 +1,6 @@
 ---
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
+
 interface Props {
   slides: { image: string }[];
   heading?: string;
@@ -43,10 +45,11 @@ const { slides, heading, description, details, border = false, perPage = 3 } = A
             >
               <img
                 sizes="(max-width: 479px) 100vw, (max-width: 767px) 50vw, 33vw"
-                srcset={`${slide.image}?fl=progressive&q=90&w=500 500w, ${slide.image}?fl=progressive&q=90&w=800 800w, ${slide.image}?fl=progressive&q=90&w=1080 1080w, ${slide.image}?fl=progressive&q=90&w=1600 1600w`}
-                src={`${slide.image}?fl=progressive`}
+                srcset={cdnSrcset(slide.image, [500, 800, 1080, 1600])}
+                src={cdnUrl(slide.image, { w: 800 })}
                 alt=""
                 loading="lazy"
+                decoding="async"
               />
             </div>
           ))}
@@ -58,10 +61,11 @@ const { slides, heading, description, details, border = false, perPage = 3 } = A
             >
               <img
                 sizes="(max-width: 479px) 100vw, (max-width: 767px) 50vw, 33vw"
-                srcset={`${slide.image}?fl=progressive&q=90&w=500 500w, ${slide.image}?fl=progressive&q=90&w=800 800w, ${slide.image}?fl=progressive&q=90&w=1080 1080w, ${slide.image}?fl=progressive&q=90&w=1600 1600w`}
-                src={`${slide.image}?fl=progressive`}
+                srcset={cdnSrcset(slide.image, [500, 800, 1080, 1600])}
+                src={cdnUrl(slide.image, { w: 800 })}
                 alt=""
                 loading="lazy"
+                decoding="async"
               />
             </div>
           ))}

--- a/src/components/ImageCentered.astro
+++ b/src/components/ImageCentered.astro
@@ -1,5 +1,6 @@
 ---
 import BlurImage from './BlurImage.astro';
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
 
 interface Props {
   imageUrl: string;
@@ -14,9 +15,9 @@ const { imageUrl, align, imageClass } = Astro.props;
   <div class="block-image dark">
     <div class:list={["block-image-inner", { "padding-bottom--0": align === "bottom" }]}>
       <BlurImage
-        src={imageUrl}
+        src={cdnUrl(imageUrl, { w: 1080 })}
         sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, (max-width: 1403px) 78vw, 1095px"
-        srcset={`${imageUrl}?fl=progressive&q=90&w=500 500w, ${imageUrl}?fl=progressive&q=90&w=800 800w, ${imageUrl}?fl=progressive&q=90&w=1080 1080w, ${imageUrl} 1095w`}
+        srcset={cdnSrcset(imageUrl, [500, 800, 1080, 1095])}
         class={imageClass}
       />
     </div>

--- a/src/components/ImageFullBleed.astro
+++ b/src/components/ImageFullBleed.astro
@@ -1,5 +1,6 @@
 ---
 import BlurImage from './BlurImage.astro';
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
 
 interface Props {
   imageUrl: string;
@@ -11,9 +12,9 @@ const { imageUrl } = Astro.props;
 <section class="section">
   <div class="block-image">
     <BlurImage
-      src={imageUrl}
+      src={cdnUrl(imageUrl, { w: 1080 })}
       sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 91vw"
-      srcset={`${imageUrl}?fl=progressive&q=90&w=500 500w, ${imageUrl}?fl=progressive&q=90&w=800 800w, ${imageUrl}?fl=progressive&q=90&w=1080 1080w, ${imageUrl} 1318w`}
+      srcset={cdnSrcset(imageUrl, [500, 800, 1080, 1318])}
     />
   </div>
 </section>

--- a/src/components/ImageSlideshow.astro
+++ b/src/components/ImageSlideshow.astro
@@ -1,4 +1,6 @@
 ---
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
+
 interface Props {
   slides: { image: string }[];
   align?: string;
@@ -20,11 +22,12 @@ const { slides, align, imageClass } = Astro.props;
               role="group"
             >
               <img
-                src={slide.image}
+                src={cdnUrl(slide.image, { w: 1080 })}
                 sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, (max-width: 1397px) 78vw, 1090px"
-                srcset={`${slide.image}?fl=progressive&q=90&w=500 500w, ${slide.image}?fl=progressive&q=90&w=800 800w, ${slide.image}?fl=progressive&q=90&w=1080 1080w, ${slide.image}?fl=progressive&q=90&w=1600 1600w`}
+                srcset={cdnSrcset(slide.image, [500, 800, 1080, 1600])}
                 alt=""
                 loading="lazy"
+                decoding="async"
                 class={imageClass}
               />
             </div>

--- a/src/components/ProjectHero.astro
+++ b/src/components/ProjectHero.astro
@@ -1,5 +1,6 @@
 ---
 import BlurImage from './BlurImage.astro';
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
 
 interface Props {
   imageUrl: string;
@@ -12,10 +13,11 @@ const { imageUrl, title } = Astro.props;
 <section class="section">
   <h1 class="heading center">{title}</h1>
   <BlurImage
-    src={imageUrl}
+    src={cdnUrl(imageUrl, { w: 1080 })}
     sizes="(max-width: 479px) 92vw, (max-width: 767px) 95vw, (max-width: 991px) 92vw, 91vw"
-    srcset={`${imageUrl}?fl=progressive&q=90&w=500 500w, ${imageUrl}?fl=progressive&q=90&w=800 800w, ${imageUrl}?fl=progressive&q=90&w=1080 1080w, ${imageUrl} 1318w`}
+    srcset={cdnSrcset(imageUrl, [500, 800, 1080, 1318])}
     class="margin-top-60"
     loading="eager"
+    fetchpriority="high"
   />
 </section>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,8 +18,12 @@ const { title } = Astro.props;
   <title>{title}</title>
   <link rel="apple-touch-icon" href="/apple-touch-icon.png">
   <link rel="alternate" type="application/rss+xml" title="Designbysoil" href="/feed.xml">
+  <!-- Warm up the image CDN connection: every image is served cross-origin from Contentful -->
+  <link rel="preconnect" href="https://images.ctfassets.net" crossorigin>
+  <link rel="dns-prefetch" href="https://images.ctfassets.net">
   <link rel="preload" href="/fonts/SuisseIntl-Regular.woff2" as="font" type="font/woff2" crossorigin>
   <!-- Google tag (gtag.js) -->
+  <link rel="preconnect" href="https://www.googletagmanager.com">
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-CZP9MB8BPY"></script>
   <script is:inline>
     window.dataLayer = window.dataLayer || [];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,6 +43,10 @@ const { title } = Astro.props;
 </html>
 
 <style is:global>
+  /* The .reveal class is added by JS only to below-the-fold elements, so
+     above-the-fold content (header, hero) paints immediately and stays
+     LCP-eligible. The header is intentionally NOT hidden on load — the logo
+     is often the LCP element, so an opacity:0 entrance would delay LCP. */
   .reveal {
     opacity: 0;
     transform: translateY(24px);
@@ -51,18 +55,6 @@ const { title } = Astro.props;
   }
 
   .reveal.is-visible {
-    opacity: 1;
-    transform: translateY(0);
-  }
-
-  .header-wrapper {
-    opacity: 0;
-    transform: translateY(-12px);
-    transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
-                transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-  }
-
-  .header-wrapper.is-visible {
     opacity: 1;
     transform: translateY(0);
   }
@@ -78,10 +70,30 @@ const { title } = Astro.props;
     opacity: 1;
     transform: translateY(0);
   }
+
+  /* Reveal animations are opt-in motion; honour the user's reduced-motion
+     preference by showing everything immediately. */
+  @media (prefers-reduced-motion: reduce) {
+    .reveal,
+    .footer-wrapper {
+      opacity: 1 !important;
+      transform: none !important;
+      transition: none !important;
+    }
+  }
 </style>
 
 <script>
   function initRevealAnimations() {
+    // Respect reduced-motion: leave all content visible, skip reveal entirely.
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    // Above-the-fold content must not be hidden on load — hiding it (opacity:0)
+    // delays LCP and causes a flash. Only animate elements that start below the
+    // fold; in-view elements render immediately and stay put.
+    const foldLine = window.innerHeight * 0.9;
+    const isAboveFold = (el: Element) => el.getBoundingClientRect().top < foldLine;
+
     const staggerContainers = '.block-grid, .project-grid, .project-list, .grid-list';
     const staggerChildren = document.querySelectorAll(
       '.page-wrapper > section .block-grid > *, ' +
@@ -90,15 +102,15 @@ const { title } = Astro.props;
       '.page-wrapper > section .grid-list'
     );
 
-    // Sections without stagger children get their own reveal
+    // Sections without stagger children get their own reveal (below fold only)
     document.querySelectorAll('.page-wrapper > section').forEach((section) => {
-      if (!section.querySelector(staggerContainers)) {
+      if (!section.querySelector(staggerContainers) && !isAboveFold(section)) {
         section.classList.add('reveal');
       }
     });
 
     staggerChildren.forEach((el) => {
-      el.classList.add('reveal');
+      if (!isAboveFold(el)) el.classList.add('reveal');
     });
 
     const allRevealElements = document.querySelectorAll('.reveal');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import HeroArt from '../components/HeroArt.astro';
 import AvailabilityMarquee from '../components/AvailabilityMarquee.astro';
-import { Image } from 'astro:assets';
+import { cdnUrl, cdnSrcset } from '../utils/contentfulImage';
 import projects from '../data/projects.yaml';
 ---
 
@@ -28,7 +28,14 @@ import projects from '../data/projects.yaml';
         <a href={project.page}>
           {project.title}
           <div class="media">
-            <Image src={`${project.thumbnail}?w=800&q=85&fl=progressive`} alt={project.title} inferSize />
+            <img
+              src={cdnUrl(project.thumbnail, { w: 600, q: 85 })}
+              srcset={cdnSrcset(project.thumbnail, [300, 600, 900], { q: 85 })}
+              sizes="300px"
+              alt={project.title}
+              loading="lazy"
+              decoding="async"
+            />
           </div>
           <div class="toolkit small">
             {project.toolkit}

--- a/src/utils/contentfulImage.ts
+++ b/src/utils/contentfulImage.ts
@@ -1,0 +1,60 @@
+// Helpers for building optimized Contentful Image API URLs.
+// All site images are served from the Contentful CDN (images.ctfassets.net);
+// these helpers centralize format/quality/resize params so every component
+// requests modern formats (WebP) and responsive sizes consistently.
+
+const CDN_HOST = 'images.ctfassets.net';
+
+export type CdnFormat = 'webp' | 'avif' | 'jpg' | 'png';
+
+export interface CdnOptions {
+  /** Target width in px. Omit for intrinsic size. */
+  w?: number;
+  /** Quality 1–100. Defaults to 80 (WebP at 80 is visually lossless and much smaller than JPEG q90). */
+  q?: number;
+  /** Output format. Defaults to 'webp'. */
+  fm?: CdnFormat;
+  /** Contentful resize behaviour (e.g. 'fill'). Omit for default. */
+  fit?: 'fill' | 'pad' | 'crop' | 'scale' | 'thumb';
+}
+
+/** True only for Contentful-hosted URLs we can safely transform. */
+export function isContentful(url: string | undefined | null): url is string {
+  return typeof url === 'string' && url.includes(CDN_HOST);
+}
+
+/**
+ * Build an optimized Contentful URL. Non-Contentful URLs (or empty values)
+ * are returned unchanged so callers can pass any src safely.
+ */
+export function cdnUrl(url: string, opts: CdnOptions = {}): string {
+  if (!isContentful(url)) return url;
+
+  const base = url.split('?')[0];
+  const { w, q = 80, fm = 'webp', fit } = opts;
+
+  const params = new URLSearchParams();
+  if (w) params.set('w', String(w));
+  params.set('q', String(q));
+  if (fm) params.set('fm', fm);
+  if (fit) params.set('fit', fit);
+  // `fl=progressive` is JPEG-only on the Contentful Images API — pairing it
+  // with webp/avif returns HTTP 400. Only add it for JPEG output.
+  if (!fm || fm === 'jpg') params.set('fl', 'progressive');
+
+  return `${base}?${params.toString()}`;
+}
+
+/**
+ * Build a responsive `srcset` of WebP (or given format) variants at the
+ * supplied widths. Returns undefined for non-Contentful URLs so the `<img>`
+ * simply falls back to its `src`.
+ */
+export function cdnSrcset(
+  url: string,
+  widths: number[],
+  opts: Omit<CdnOptions, 'w'> = {},
+): string | undefined {
+  if (!isContentful(url)) return undefined;
+  return widths.map((w) => `${cdnUrl(url, { ...opts, w })} ${w}w`).join(', ');
+}


### PR DESCRIPTION
## Summary
Upgrades Astro **6.3.7 → 7.0.4** and ships a visitor-facing image-performance refactor (keeping Contentful CDN delivery).

### Astro 7 upgrade
- Vite 8 / Rolldown + Rust compiler. `engines.node` → `>=22`. Build time **~22s → ~2.5s**.
- `@rollup/plugin-yaml` verified working under Rolldown; pruned stale extraneous `@astrojs/netlify`.

### Performance (visitor-facing)
- New `src/utils/contentfulImage.ts` — `cdnUrl`/`cdnSrcset` build WebP + responsive variants. Drops `fl=progressive` for non-JPEG (Contentful returns 400 otherwise).
- **WebP on all images ≈ 85% smaller.** Heroes are PNGs that were being served full-size because the old `fl=progressive` flag is JPEG-only. Health-desk hero: **269 KB → 40 KB**.
- `preconnect` to `images.ctfassets.net` (+ GA); `decoding="async"` throughout.
- `fetchpriority="high"` on `ProjectHero` (real LCP). Homepage thumbnails kept lazy (hover-reveal, not LCP). Gallery srcset/sizes wired for Contentful fallbacks.

### Verification
All 10 pages build + return 200; full Playwright visual QA (0 console errors); sitemap generated.

### Follow-ups (out of scope)
Real-dimension CLS hardening, carousel component consolidation, off-screen animation gating, AVIF via `<picture>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)